### PR TITLE
Deprecated use of start changed to start_app

### DIFF
--- a/script/boilerplate
+++ b/script/boilerplate
@@ -17,4 +17,4 @@ EOF
 $ENV{MOJO_APP} ||= 'Boilerplate';
 
 # Start commands
-Mojolicious::Commands->start;
+Mojolicious::Commands->start_app($ENV{MOJO_APP});


### PR DESCRIPTION
Fix the problem reported by others in the issues section
